### PR TITLE
Revert "Update shipment carried_id according to live environment"

### DIFF
--- a/src/MyParcelApi.Net/Models/Shipment.cs
+++ b/src/MyParcelApi.Net/Models/Shipment.cs
@@ -45,7 +45,7 @@ namespace MyParcelApi.Net.Models
         [DataMember(Name = "physical_properties", EmitDefaultValue = false, IsRequired = false)]
         public PhysicalProperties PhysicalProperties { get; set; }
 
-        [DataMember(Name = "carrier_id", EmitDefaultValue = false, IsRequired = false)]
+        [DataMember(Name = "carrier", EmitDefaultValue = false, IsRequired = false)]
         public Carrier Carrier { get; set; }
 
         [DataMember(Name = "created", EmitDefaultValue = false)]


### PR DESCRIPTION
Reverts janssenr/MyParcelApi.Net#5

Reverted this change, because of error when creating a shipment:
{
   "errors":[
      {
         "code":0,
         "fields":[
            "data.shipments[0].carrier",
            "data.shipments[0]"
         ],
         "human":[
            "data.shipments[0].carrier The property carrier is required",
            "data.shipments[0] The property carrier_id is not defined and the definition does not allow additional properties"
         ]
      }
   ],
   "message":"Failed validation against JSON-SCHEMA shipment\/post_shipments_request.json"
}

Will create an issue for the MyParcel API.