### PR TITLE
Carrier is set when it's available 

### DIFF
--- a/src/MyParcelApi.Net/Models/Carrier.cs
+++ b/src/MyParcelApi.Net/Models/Carrier.cs
@@ -2,6 +2,7 @@
 {
     public enum Carrier
     {
+        None = 0,
         PostNl = 1,
         BPost = 2
     }

--- a/src/MyParcelApi.Net/Models/Shipment.cs
+++ b/src/MyParcelApi.Net/Models/Shipment.cs
@@ -48,6 +48,27 @@ namespace MyParcelApi.Net.Models
         [DataMember(Name = "carrier", EmitDefaultValue = false, IsRequired = false)]
         public Carrier Carrier { get; set; }
 
+        /// <summary>
+        /// This is a workarround for a bug in the MyParcelApi where there is inconsistency between getting the Carriers [GET] and Creating/Updating them [POST/PUT].
+        /// It's also possible to be null
+        /// </summary>
+        [DataMember(Name = "carrier_id", EmitDefaultValue = false, IsRequired = false)]
+        private Carrier? CarrierFallback
+        {
+            get
+            {
+                return Carrier;
+            }
+            set
+            {
+                if(value.HasValue)
+                {
+                    Carrier = value.Value;
+                }
+               
+            }
+        }
+
         [DataMember(Name = "created", EmitDefaultValue = false)]
         public DateTime Created { get; set; }
 


### PR DESCRIPTION
Added support for Getting the shipments carrier, since the property was different from a Create or Update.

There was an edge case also with the following shipment, which was a retour ( see included json).
So i added 0 as Carrier 

Since an enum value is set to Zero by default, if it's not nullable. Since that is always a possible value for an enum, even if it's not declared

The Fallback value is nullable, so it's only set when it has one.
It's private, so it won't interfere with other stuff, serialization works.


      {  
            "id":xxx,
            "parent_id":xx,
            "account_id":xxx,
            "shop_id":xxx,
            "shipment_type":2,
            "recipient":{  
               "cc":"BE",
               "city":"Alveringem",
               "street":"xxx",
               "number":"11",
               "company":"Blinde Vis",
               "email":"infxxxe",
               "phone":"32500000000",
               "postal_code":"8690",
               "person":"Nico Sap",
               "account_id":xxxx,
               "street_additional_info":"",
               "number_suffix":"",
               "box_number":""
            },
            "sender":{  
               "cc":"BE",
               "city":"Antwxxxijk",
               "person":"Hxxxkel",
               "company":"",
               "email":"",
               "phone":"",
               "street":"xxxx",
               "number":"4",
               "box_number":"",
               "postal_code":"2610"
            },
            "status":7,
            "options":{  
               "package_type":1,
               "signature":0,
               "only_recipient":0,
               "return":0,
               "large_format":0,
               "cooled_delivery":0,
               "saturday_delivery":0,
               "label_description":"retour - 32321162xxxx30",
               "insurance":{  
                  "amount":0,
                  "currency":"EUR"
               },
               "contribution":{  
                  "amount":0,
                  "currency":"EUR"
               }
            },
            "general_settings":{  
               "save_recipient_address":1,
               "tracktrace":{  
                  "delivery_notification":0,
                  "send_track_trace_emails":1,
                  "email_on_handed_to_courier":0,
                  "bcc":0,
                  "from_address_email":"infxxxe",
                  "from_address_company":"Blinde Vis",
                  "carrier_email_basic_notification":0
               }
            },
            "pickup":null,
            "customs_declaration":null,
            "physical_properties":{  
               "carrier_height":null,
               "carrier_width":null,
               "carrier_weight":240,
               "carrier_length":null,
               "carrier_volume":null,
               "height":0,
               "width":0,
               "length":0,
               "volume":0,
               "weight":240
            },
            "created":"2018-12-18T00:00:00+01:00",
            "modified":"2019-02-09T18:45:23+01:00",
            "reference_identifier":null,
            "created_by":29763,
            "modified_by":29763,
            "transaction_status":"paid",
            "price":{  
               "amount":850,
               "currency":"EUR"
            },
            "barcode":"3xxxx8030",
            "region":"BE",
            "external_provider":null,
            "external_provider_id":null,
            "payment_status":"paid",
            "carrier_id":2,
            "platform_id":3,
            "origin":null,
            "user_agent":null,
            "secondary_shipments":[  

            ],
            "multi_collo_main_shipment_id":null
         },
         {  
            "options":{  
               "package_type":1,
               "signature":0,
               "only_recipient":0,
               "return":0,
               "large_format":0,
               "cooled_delivery":0,
               "saturday_delivery":0,
               "label_description":"retour - 323211623959932599909030",
               "insurance":{  
                  "amount":0,
                  "currency":"EUR"
               },
               "contribution":{  
                  "amount":0,
                  "currency":"EUR"
               }
            },
            "account_id":1xxx,
            "shop_id":xxx,
            "general_settings":{  
               "save_recipient_address":1,
               "tracktrace":{  
                  "delivery_notification":0,
                  "send_track_trace_emails":1,
                  "email_on_handed_to_courier":0,
                  "bcc":0,
                  "from_address_email":"ixxxxe",
                  "from_address_company":"Blinde Vis",
                  "carrier_email_basic_notification":0
               }
            },
            "sender":{  
               "cc":"BE",
               "city":"Antxxxk",
               "person":"xxxx",
               "company":"",
               "email":"",
               "phone":"",
               "street":"Cxxxlaan",
               "number":"4",
               "box_number":"",
               "postal_code":"2610"
            },
            "recipient":{  
               "cc":"BE",
               "city":"Alveringem",
               "street":"Westover",
               "number":"1",
               "company":"Blinde Vis",
               "email":"inxxxe",
               "phone":"32xxx0",
               "postal_code":"8xx0",
               "person":"Nico Sap",
               "account_id":1xx3,
               "street_additional_info":"",
               "number_suffix":"",
               "box_number":""
            },
            "physical_properties":{  
               "weight":240
            },
            "shipment_type":2,
            "parent_id":40979928,
            "created_by":29763,
            "modified_by":29763,
            "status":1,
            "modified":"2018-12-19T18:31:57+01:00",
            "created":"2018-12-19T00:00:00+01:00",
            "id":xxx,
            "price":{  
               "amount":451,
               "currency":"EUR"
            },
            "barcode":"",
            "region":"",
            "external_provider":null,
            "external_provider_id":null,
            "payment_status":null,
            "carrier_id":null,
            "platform_id":3,
            "origin":null,
            "user_agent":null,
            "secondary_shipments":[  

            ],
            "multi_collo_main_shipment_id":null
         },